### PR TITLE
[#182320270] dont pass boxShadow prop to dom element

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,7 @@ module.exports = {
     'react/prop-types': 0,
     'no-empty': ['error', { allowEmptyCatch: true }],
     '@typescript-eslint/explicit-module-boundary-types': 0,
-    'no-unused-vars': [
+    '@typescript-eslint/no-unused-vars': [
       'error',
       {
         vars: 'all',

--- a/src/components/share_buttons/shapes.tsx
+++ b/src/components/share_buttons/shapes.tsx
@@ -31,7 +31,15 @@ const ButtonFull: React.FC<ButtonProps> = ({
   )
 }
 
-const ButtonMinimal: React.FC<ButtonProps> = ({ icon, content, className = '', buttonClassName = '', ...props }) => {
+const ButtonMinimal: React.FC<ButtonProps> = ({
+  icon,
+  content,
+  className = '',
+  buttonClassName = '',
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  boxShadow,
+  ...props
+}) => {
   const Icon = icon
 
   return (
@@ -55,7 +63,14 @@ const ButtonRound: React.FC<ButtonProps> = ({ icon, className = '', boxShadow, b
   )
 }
 
-const ButtonSquare: React.FC<ButtonProps> = ({ icon, className = '', buttonClassName = '', ...props }) => {
+const ButtonSquare: React.FC<ButtonProps> = ({
+  icon,
+  className = '',
+  buttonClassName = '',
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  boxShadow,
+  ...props
+}) => {
   const Icon = icon
 
   return (

--- a/src/components/share_buttons/shapes.tsx
+++ b/src/components/share_buttons/shapes.tsx
@@ -36,8 +36,7 @@ const ButtonMinimal: React.FC<ButtonProps> = ({
   content,
   className = '',
   buttonClassName = '',
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  boxShadow,
+  boxShadow: _,
   ...props
 }) => {
   const Icon = icon
@@ -67,8 +66,7 @@ const ButtonSquare: React.FC<ButtonProps> = ({
   icon,
   className = '',
   buttonClassName = '',
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  boxShadow,
+  boxShadow: _,
   ...props
 }) => {
   const Icon = icon


### PR DESCRIPTION
Fixes `Warning: React does not recognize the boxShadow prop on a DOM element.`

Explanation: `boxShadow` was passed to the `<a>` tag together with the rest parameters (`...props`), even though it is not used. This is now avoided by explicitly excluding it from props.

See https://www.pivotaltracker.com/story/show/182320270